### PR TITLE
Can set a custom formatter via config settings.

### DIFF
--- a/.github/workflows/MergeToMain.yml
+++ b/.github/workflows/MergeToMain.yml
@@ -12,11 +12,12 @@ env:
 
 jobs:
   build_and_create_a_nuget:
+    name: Build and create a BETA NuGet package (GPR)
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build version prefix/suffix
         run: |
@@ -24,7 +25,7 @@ jobs:
           echo "VERSION_SUFFIX=beta" >> $GITHUB_ENV
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
 
       - run: dotnet restore --verbosity minimal
 
@@ -33,7 +34,7 @@ jobs:
       - run: dotnet pack --configuration Release --no-build --output ./artifacts -p:VersionPrefix=$VERSION_PREFIX --version-suffix $VERSION_SUFFIX -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
 
       - name: Publish artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: NuGetPackage.${{ env.VERSION_PREFIX }}-${{ env.VERSION_SUFFIX }}.nupkg.zip
           path: ./artifacts/*

--- a/.github/workflows/PullRequest.yml
+++ b/.github/workflows/PullRequest.yml
@@ -9,12 +9,13 @@ env:
 
 jobs:
 
-  build_and_test_release:
+  build_and_pack_release:
+    name: Build and pack release
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build version prefix/suffix
         run: |
@@ -22,7 +23,7 @@ jobs:
           echo "VERSION_SUFFIX=alpha" >> $GITHUB_ENV
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
 
       - run: dotnet restore --verbosity minimal
 
@@ -31,7 +32,7 @@ jobs:
       - run: dotnet pack --configuration Release --no-build --output ./artifacts -p:VersionPrefix=$VERSION_PREFIX --version-suffix $VERSION_SUFFIX -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
 
       - name: Publish artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: NuGetPackage.${{ env.VERSION_PREFIX }}-${{ env.VERSION_SUFFIX }}.nupkg.zip
           path: ./artifacts/*

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -14,7 +14,8 @@ env:
   DOTNET_NOLOGO: true
 
 jobs:
-  build:
+  build_and_create_a_nuget:
+    name: Build and create a NuGet package (GPR and NuGet.org)
     runs-on: ubuntu-latest
 
     steps:
@@ -23,10 +24,10 @@ jobs:
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
 
       - run: dotnet restore --verbosity minimal
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ This sink is also configured for the most common scenario's - an easy way to get
 
 ### Table of Contents
 - [Getting started (simple, text based logging)](#getting-started-simple-text-based-logging)
-- [More advanced getting started (loading settings via configuration file)](#more-advanced-getting-started-loading-settings-via-configuration-file)
+- [Advanced: loading InsightOps settings via configuration file](#more-advanced-getting-started-loading-settings-via-configuration-file)
 - [Structured Logging](#structured-logging)
+- [Advanced Structured Logging: loading InsightOps settings via configuration file](#structured-logging-advanced-settings-via-configuration-file)
 
 <hr/>
 
@@ -96,6 +97,38 @@ Here's a lovely example:
 
 ![image](https://user-images.githubusercontent.com/899878/148729173-f2a6f368-15fa-4c61-930a-9432bcf34957.png)
 
+<details>
+<summary>Example appSettings.json code (copy/paste friendly)</summary>
+
+```
+{
+    "Serilog": {
+        "Using": [ "Serilog.Sinks.InsightOps" ],
+        "MinimumLevel": {
+            "Default": "Debug",
+            "Override": {
+                "System": "Debug",
+                "Microsoft": "Debug"
+            }
+        },
+        "WriteTo": [
+            {
+                "Name": "Console"
+            },
+            {
+                "Name": "InsightOps",
+                "Args": {
+                    "Token": "<to be manually set>",
+                    "Region": "au",
+                    "UseSsl": "true"
+                }
+            }
+        ]
+    }
+}
+```
+
+</details>
 
 ## Structured Logging
 
@@ -119,9 +152,44 @@ and this will now send the data up to insightOps as Structed Logging:
 
 For the record, there are the types of JSON data formats you can use:
 
-- `JsonFormatter()`
-- `CompactJsonFormatter()`
-- `RenderedCompactJsonFormatter()`
+- `JsonFormatter()` 
+- `CompactJsonFormatter()` [This has no `@m` "message" property. Only the `@mt` "message template"]
+- `RenderedCompactJsonFormatter()` [This has an `@m` message property, plus other values]
+
+## Structured Logging (Advanced) : Settings via configuration file
+
+Here's an example section of loading the settings via the `appSettings.config` file:
+
+Note the `Formatter` arg.
+
+```
+{
+    "Serilog": {
+        "Using": [ "Serilog.Sinks.InsightOps" ],
+        "MinimumLevel": {
+            "Default": "Debug",
+            "Override": {
+                "System": "Debug",
+                "Microsoft": "Debug"
+            }
+        },
+        "WriteTo": [
+            {
+                "Name": "Console"
+            },
+            {
+                "Name": "InsightOps",
+                "Args": {
+                    "Token": "<to be manually set>",
+                    "Region": "au",
+                    "UseSsl": "true",
+                    "Formatter": "Serilog.Formatting.Compact.RenderedCompactJsonFormatter, Serilog.Formatting.Compact"
+                }
+            }
+        ]
+    }
+}
+```
 
 For more detailed explanation of these, [this is a blog post](https://nblumhardt.com/2016/07/serilog-2-0-json-improvements/) from the Serilog author.
 

--- a/src/Serilog.Sinks.InsightOps/LoggerSinkConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.InsightOps/LoggerSinkConfigurationExtensions.cs
@@ -12,12 +12,40 @@ namespace Serilog.Sinks.InsightOps
         const string DefaultOutputTemplate = "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}";
 
         /// <summary>
-        /// Writes events logs to insightOps.
+        /// Configuration file POCO class: writes events logs to insightOps.
         /// </summary>
         /// <param name="sinkConfiguration">Logger sink configuration.</param>
         /// <param name="token">Secret token which links these logs to your logset/account.</param>
         /// <param name="region">Region to send data to. User: au, eu, us, ca, jp.</param>
         /// <param name="useSsl">Use SSL or not. (SSl -might- have a slight performance hit, but don't quote me on that).</param>
+        /// <param name="restrictedToMinimumLevel">The minimum level for events passed through the sink. Ignored when levelSwitch is specified.</param>
+        /// <param name="formatter">The formatter to log events in a textual representation. E.G. a compact Json representation for structured logging.</param>
+        /// <param name="levelSwitch">A switch allowing the pass-through minimum level to be changed at runtime.</param>
+        /// <returns></returns>
+        public static LoggerConfiguration InsightOps(
+            this LoggerSinkConfiguration sinkConfiguration,
+            string token,
+            string region,
+            ITextFormatter formatter = null,
+            bool useSsl = true,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            LoggingLevelSwitch levelSwitch = null)
+        {
+            // We need a formatter, so lets use the other constructor.
+            if (formatter == null)
+            {
+                return InsightOps(sinkConfiguration, token, region, useSsl, restrictedToMinimumLevel, DefaultOutputTemplate, null, levelSwitch);
+            }
+
+            // We have a custom formatter, so we need to use the custom output template.
+            return InsightOps(sinkConfiguration, token, region, useSsl, formatter, restrictedToMinimumLevel, levelSwitch);
+        }
+
+        /// <summary>
+        /// Configuration file POCO class: writes events logs to insightOps.
+        /// </summary>
+        /// <param name="sinkConfiguration">Logger sink configuration.</param>
+        /// <param name="settings">Configuration settings.</param>
         /// <param name="restrictedToMinimumLevel">The minimum level for events passed through the sink. Ignored when levelSwitch is specified.</param>
         /// <param name="outputTemplate">Custom output template. If not provided, will default to <code>[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}</code></param>
         /// <param name="formatProvider">Optional: Supplies culture-specific formatting information, or null.</param>
@@ -31,42 +59,8 @@ namespace Serilog.Sinks.InsightOps
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             string outputTemplate = DefaultOutputTemplate,
             IFormatProvider formatProvider = null,
-            LoggingLevelSwitch levelSwitch = null) => InsightOps(
-                sinkConfiguration,
-                new InsightOpsSinkSettings
-                {
-                    Token = token,
-                    Region = region,
-                    UseSsl = useSsl
-                },
-                restrictedToMinimumLevel,
-                outputTemplate,
-                formatProvider,
-                levelSwitch);
-
-        /// <summary>
-        /// Writes events logs to insightOps.
-        /// </summary>
-        /// <param name="sinkConfiguration">Logger sink configuration.</param>
-        /// <param name="config">Configuration settings.</param>
-        /// <param name="restrictedToMinimumLevel">The minimum level for events passed through the sink. Ignored when levelSwitch is specified.</param>
-        /// <param name="outputTemplate">Custom output template. If not provided, will default to <code>[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}</code></param>
-        /// <param name="formatProvider">Optional: Supplies culture-specific formatting information, or null.</param>
-        /// <param name="levelSwitch">A switch allowing the pass-through minimum level to be changed at runtime.</param>
-        /// <returns></returns>
-        public static LoggerConfiguration InsightOps(
-            this LoggerSinkConfiguration sinkConfiguration,
-            InsightOpsSinkSettings config,
-            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            string outputTemplate = DefaultOutputTemplate,
-            IFormatProvider formatProvider = null,
             LoggingLevelSwitch levelSwitch = null)
         {
-            if (config is null)
-            {
-                throw new ArgumentNullException(nameof(config));
-            }
-
             if (string.IsNullOrWhiteSpace(outputTemplate))
             {
                 throw new ArgumentException($"'{nameof(outputTemplate)}' cannot be null or whitespace", nameof(outputTemplate));
@@ -74,27 +68,40 @@ namespace Serilog.Sinks.InsightOps
 
             var formatter = new MessageTemplateTextFormatter(outputTemplate, formatProvider);
 
-            return sinkConfiguration.InsightOps(config, formatter, restrictedToMinimumLevel, levelSwitch);
+            return sinkConfiguration.InsightOps(token, region, formatter, useSsl, restrictedToMinimumLevel, levelSwitch);
         }
 
+        /// <summary>
+        /// Configuration file POCO class: writes events logs to insightOps.
+        /// </summary>
+        /// <param name="sinkConfiguration">Logger sink configuration.</param>
+        /// <param name="settings">Configuration settings.</param>
+        /// <param name="formatter">The formatter to log events in a textual representation. E.G. a compact Json representation for structured logging.</param>
+        /// <param name="restrictedToMinimumLevel">The minimum level for events passed through the sink. Ignored when levelSwitch is specified.</param>
+        /// <param name="levelSwitch">A switch allowing the pass-through minimum level to be changed at runtime.</param>
+        /// <returns></returns>
         public static LoggerConfiguration InsightOps(
             this LoggerSinkConfiguration sinkConfiguration,
-            InsightOpsSinkSettings config,
-            ITextFormatter formatter,
+            string token,
+            string region,
+            bool useSsl = true,
+            ITextFormatter formatter = null,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             LoggingLevelSwitch levelSwitch = null)
         {
-            if (config is null)
+            var settings = new InsightOpsSinkSettings
             {
-                throw new ArgumentNullException(nameof(config));
-            }
+                Token = token,
+                Region = region,
+                UseSsl = useSsl
+            };
 
             if (formatter is null)
             {
                 throw new ArgumentNullException(nameof(formatter));
             }
 
-            var sink = new InsightOpsSink(config, formatter);
+            var sink = new InsightOpsSink(settings, formatter);
 
             return sinkConfiguration.Sink(sink, restrictedToMinimumLevel, levelSwitch);
         }

--- a/src/Serilog.Sinks.InsightOps/Serilog.Sinks.InsightOps.csproj
+++ b/src/Serilog.Sinks.InsightOps/Serilog.Sinks.InsightOps.csproj
@@ -29,7 +29,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="R7Insight.Core" Version="2.9.3" />
-    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="Serilog" Version="3.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Serilog.Sinks.InsightOps.ConsoleTest/Program.cs
+++ b/tests/Serilog.Sinks.InsightOps.ConsoleTest/Program.cs
@@ -15,17 +15,14 @@ namespace Serilog.Sinks.InsightOps.ConsoleTest
             Console.WriteLine("Starting.");
             
             // NOTE: Please replace with your own settings.
-            var settings = new InsightOpsSinkSettings
-            {
-                Region = "au", // au, eu, jp or us
-                Token = "<some guid from your account>",
-                UseSsl = false
-            };
+            const string region = "au"; // au, eu, jp or us.
+            const string token = "<some guid from your account>";
+            const bool useSsl = false;
 
             // Create our logger.
             var log = new LoggerConfiguration()
                 .MinimumLevel.Debug()
-                .WriteTo.InsightOps(settings, new RenderedCompactJsonFormatter())
+                .WriteTo.InsightOps(region, token, new RenderedCompactJsonFormatter(), useSsl)
                 .WriteTo.Console(new CompactJsonFormatter())
                 .WriteTo.Seq("http://localhost:5301")
                 .CreateLogger();

--- a/tests/Serilog.Sinks.InsightOps.ConsoleTest/Serilog.Sinks.InsightOps.ConsoleTest.csproj
+++ b/tests/Serilog.Sinks.InsightOps.ConsoleTest/Serilog.Sinks.InsightOps.ConsoleTest.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
-    <PackageReference Include="Serilog.Sinks.Seq" Version="5.1.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+    <PackageReference Include="Serilog.Sinks.Seq" Version="5.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Serilog.Sinks.InsightOps.ConsoleWithConfigTest/Serilog.Sinks.InsightOps.ConsoleWithConfigTest.csproj
+++ b/tests/Serilog.Sinks.InsightOps.ConsoleWithConfigTest/Serilog.Sinks.InsightOps.ConsoleWithConfigTest.csproj
@@ -8,9 +8,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
-    <PackageReference Include="Serilog.Sinks.Seq" Version="5.1.0" />
+    <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="7.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+    
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Serilog.Sinks.InsightOps.ConsoleWithConfigTest/appsettings.json
+++ b/tests/Serilog.Sinks.InsightOps.ConsoleWithConfigTest/appsettings.json
@@ -1,6 +1,6 @@
 {
     "Serilog": {
-        "Using": [ "Serilog.Sinks.Seq", "Serilog.Sinks.InsightOps" ],
+        "Using": [ "Serilog.Sinks.InsightOps" ],
         "MinimumLevel": {
             "Default": "Debug",
             "Override": {
@@ -13,18 +13,12 @@
                 "Name": "Console"
             },
             {
-                "Name": "Seq",
-                "Args": {
-                    "serverUrl": "http://localhost:5301",
-                    "restrictedToMinimumLevel": "Information"
-                }
-            },
-            {
                 "Name": "InsightOps",
                 "Args": {
                     "Token": "<to be manually set>",
                     "Region": "au",
-                    "UseSsl": "true"
+                    "UseSsl": "true",
+                    "Formatter": "Serilog.Formatting.Compact.RenderedCompactJsonFormatter, Serilog.Formatting.Compact"
                 }
             }
         ]


### PR DESCRIPTION
This allows the developer to define the customer formatter to use.

For example, if we wish to do structure logging, we should then use a render that allows for that:
- CompactJsonFormatter
- RenderedCompactJsonFormatter

this PR allows developers to define their choice, in the `appSettings.json` file.