### PR TITLE
🛠️ Fix broken nuget push command

### DIFF
--- a/.github/workflows/MergeToMain.yml
+++ b/.github/workflows/MergeToMain.yml
@@ -41,6 +41,6 @@ jobs:
       - name: Publish to GPR
         run: |
           dotnet nuget push "./artifacts/*.nupkg" \
-            --no-symbols true \
+            --no-symbols \
             --api-key ${{ secrets.GITHUB_TOKEN }} \
             --source https://nuget.pkg.github.com/${{ github.repository_owner }}


### PR DESCRIPTION
Known bug with `nuget` command. Yes! i just said that!

REF: https://learn.microsoft.com/en-us/nuget/release-notes/nuget-6.1#dotnet-nuget-push--n--no-symbols-or--d--disable-buffering-raises-error-file-does-not-exist--exception---11601