### PR TITLE
🚀 .NET 8 and redid Sink config extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ var settings = new InsightOpsSinkSettings
 {
     Region = "<to fill in by you>", // au, eu, jp or us
     Token = "<to fill in by you>", // Guid, taken from your InsightOps log account
-    UseSsl = false // or True for sending via HTTPS
+    UseSsl = false, // or True for sending via HTTPS. Make sure you can handle TLS1.2 (or newer)
+    Debug = false // or True to see low level R7 Insight ops debug messages in the console (this is helpful actually!)
 };
 ```
 

--- a/Serilog.Sinks.InsightOps.sln
+++ b/Serilog.Sinks.InsightOps.sln
@@ -14,7 +14,21 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{84F17F94
 		README.md = README.md
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.InsightOps.ConsoleWithConfigTest", "tests\Serilog.Sinks.InsightOps.ConsoleWithConfigTest\Serilog.Sinks.InsightOps.ConsoleWithConfigTest.csproj", "{7BC53E51-46AD-4BD5-AE1C-35C8E172E3BB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Serilog.Sinks.InsightOps.ConsoleWithConfigTest", "tests\Serilog.Sinks.InsightOps.ConsoleWithConfigTest\Serilog.Sinks.InsightOps.ConsoleWithConfigTest.csproj", "{7BC53E51-46AD-4BD5-AE1C-35C8E172E3BB}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "GitHub", "GitHub", "{58CE4CAF-70AA-4917-BF53-E4E0062115C2}"
+	ProjectSection(SolutionItems) = preProject
+		.github\CODE_OF_CONDUCT.md = .github\CODE_OF_CONDUCT.md
+		.github\CONTRIBUTING.md = .github\CONTRIBUTING.md
+		.github\FUNDING.yml = .github\FUNDING.yml
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Workflows", "Workflows", "{5247B878-4E85-464F-AD85-A899D5A6569C}"
+	ProjectSection(SolutionItems) = preProject
+		.github\workflows\MergeToMain.yml = .github\workflows\MergeToMain.yml
+		.github\workflows\PullRequest.yml = .github\workflows\PullRequest.yml
+		.github\workflows\Release.yml = .github\workflows\Release.yml
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -37,6 +51,10 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{58CE4CAF-70AA-4917-BF53-E4E0062115C2} = {84F17F94-8C46-4F5B-A4B1-D353435C2D7E}
+		{5247B878-4E85-464F-AD85-A899D5A6569C} = {58CE4CAF-70AA-4917-BF53-E4E0062115C2}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2427750A-8467-4B7E-87C6-DA138BEC8349}

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "6.0.100",
+        "version": "8.0.100",
         "rollForward": "latestFeature"
     }
 }

--- a/src/Serilog.Sinks.InsightOps/InsightOpsSink.cs
+++ b/src/Serilog.Sinks.InsightOps/InsightOpsSink.cs
@@ -45,7 +45,7 @@ namespace Serilog.Sinks.InsightOps
 
         public void Emit(LogEvent logEvent)
         {
-            if (logEvent is null)
+            if (logEvent == null)
             {
                 throw new ArgumentNullException(nameof(logEvent));
             }

--- a/src/Serilog.Sinks.InsightOps/LoggerSinkConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.InsightOps/LoggerSinkConfigurationExtensions.cs
@@ -11,99 +11,160 @@ namespace Serilog.Sinks.InsightOps
     {
         const string DefaultOutputTemplate = "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}";
 
-        /// <summary>
-        /// Configuration file POCO class: writes events logs to insightOps.
-        /// </summary>
-        /// <param name="sinkConfiguration">Logger sink configuration.</param>
-        /// <param name="token">Secret token which links these logs to your logset/account.</param>
-        /// <param name="region">Region to send data to. User: au, eu, us, ca, jp.</param>
-        /// <param name="useSsl">Use SSL or not. (SSl -might- have a slight performance hit, but don't quote me on that).</param>
-        /// <param name="restrictedToMinimumLevel">The minimum level for events passed through the sink. Ignored when levelSwitch is specified.</param>
-        /// <param name="formatter">The formatter to log events in a textual representation. E.G. a compact Json representation for structured logging.</param>
-        /// <param name="levelSwitch">A switch allowing the pass-through minimum level to be changed at runtime.</param>
-        /// <returns></returns>
         public static LoggerConfiguration InsightOps(
             this LoggerSinkConfiguration sinkConfiguration,
-            string token,
-            string region,
-            ITextFormatter formatter = null,
-            bool useSsl = true,
+            InsightOpsSinkSettings settings) => InsightOps(sinkConfiguration, settings, LevelAlias.Minimum, null);
+
+        public static LoggerConfiguration InsightOps(
+            this LoggerSinkConfiguration sinkConfiguration, 
+            InsightOpsSinkSettings settings,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             LoggingLevelSwitch levelSwitch = null)
         {
-            // We need a formatter, so lets use the other constructor.
-            if (formatter == null)
-            {
-                return InsightOps(sinkConfiguration, token, region, useSsl, restrictedToMinimumLevel, DefaultOutputTemplate, null, levelSwitch);
-            }
-
-            // We have a custom formatter, so we need to use the custom output template.
-            return InsightOps(sinkConfiguration, token, region, useSsl, formatter, restrictedToMinimumLevel, levelSwitch);
-        }
-
-        /// <summary>
-        /// Configuration file POCO class: writes events logs to insightOps.
-        /// </summary>
-        /// <param name="sinkConfiguration">Logger sink configuration.</param>
-        /// <param name="settings">Configuration settings.</param>
-        /// <param name="restrictedToMinimumLevel">The minimum level for events passed through the sink. Ignored when levelSwitch is specified.</param>
-        /// <param name="outputTemplate">Custom output template. If not provided, will default to <code>[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}</code></param>
-        /// <param name="formatProvider">Optional: Supplies culture-specific formatting information, or null.</param>
-        /// <param name="levelSwitch">A switch allowing the pass-through minimum level to be changed at runtime.</param>
-        /// <returns></returns>
-        public static LoggerConfiguration InsightOps(
-            this LoggerSinkConfiguration sinkConfiguration,
-            string token,
-            string region,
-            bool useSsl = true,
-            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            string outputTemplate = DefaultOutputTemplate,
-            IFormatProvider formatProvider = null,
-            LoggingLevelSwitch levelSwitch = null)
-        {
-            if (string.IsNullOrWhiteSpace(outputTemplate))
-            {
-                throw new ArgumentException($"'{nameof(outputTemplate)}' cannot be null or whitespace", nameof(outputTemplate));
-            }
-
-            var formatter = new MessageTemplateTextFormatter(outputTemplate, formatProvider);
-
-            return sinkConfiguration.InsightOps(token, region, formatter, useSsl, restrictedToMinimumLevel, levelSwitch);
-        }
-
-        /// <summary>
-        /// Configuration file POCO class: writes events logs to insightOps.
-        /// </summary>
-        /// <param name="sinkConfiguration">Logger sink configuration.</param>
-        /// <param name="settings">Configuration settings.</param>
-        /// <param name="formatter">The formatter to log events in a textual representation. E.G. a compact Json representation for structured logging.</param>
-        /// <param name="restrictedToMinimumLevel">The minimum level for events passed through the sink. Ignored when levelSwitch is specified.</param>
-        /// <param name="levelSwitch">A switch allowing the pass-through minimum level to be changed at runtime.</param>
-        /// <returns></returns>
-        public static LoggerConfiguration InsightOps(
-            this LoggerSinkConfiguration sinkConfiguration,
-            string token,
-            string region,
-            bool useSsl = true,
-            ITextFormatter formatter = null,
-            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            LoggingLevelSwitch levelSwitch = null)
-        {
-            var settings = new InsightOpsSinkSettings
-            {
-                Token = token,
-                Region = region,
-                UseSsl = useSsl
-            };
-
-            if (formatter is null)
-            {
-                throw new ArgumentNullException(nameof(formatter));
-            }
+            var formatter = new MessageTemplateTextFormatter(DefaultOutputTemplate);
 
             var sink = new InsightOpsSink(settings, formatter);
 
             return sinkConfiguration.Sink(sink, restrictedToMinimumLevel, levelSwitch);
         }
+
+        // NOTE: If you provide an ITextFormatter, you should also provide an output template inside that instance.
+        //       This is why this constructor doesn't offer an ITextFormatter AND an output template + IFormatProvider.
+        public static LoggerConfiguration InsightOps(
+            this LoggerSinkConfiguration sinkConfiguration,
+            InsightOpsSinkSettings settings,
+            ITextFormatter formatter = null, 
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            LoggingLevelSwitch levelSwitch = null)
+        {
+            if (formatter == null)
+            {
+                formatter = new MessageTemplateTextFormatter(DefaultOutputTemplate);
+            }
+
+            return sinkConfiguration.CreateSink(settings, formatter, restrictedToMinimumLevel, levelSwitch);
+        }
+
+        public static LoggerConfiguration InsightOps(
+            this LoggerSinkConfiguration sinkConfiguration,
+            InsightOpsSinkSettings settings,
+            string outputTemplate = DefaultOutputTemplate,
+            IFormatProvider formatProvider = null,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            LoggingLevelSwitch levelSwitch = null)
+        {
+            if (string.IsNullOrWhiteSpace(outputTemplate))
+            {
+                outputTemplate = DefaultOutputTemplate;
+            }
+
+            var formatter = new MessageTemplateTextFormatter(outputTemplate, formatProvider);
+
+            return sinkConfiguration.CreateSink(settings, formatter, restrictedToMinimumLevel, levelSwitch);
+        }
+
+        private static LoggerConfiguration CreateSink(
+            this LoggerSinkConfiguration sinkConfiguration, 
+            InsightOpsSinkSettings settings, 
+            ITextFormatter formatter,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            LoggingLevelSwitch levelSwitch = null)
+        {
+            var sink = new InsightOpsSink(settings, formatter);
+
+            return sinkConfiguration.Sink(sink, restrictedToMinimumLevel, levelSwitch);
+        }
+
+        ///// <summary>
+        ///// Configuration file POCO class: writes events logs to insightOps.
+        ///// </summary>
+        ///// <param name="sinkConfiguration">Logger sink configuration.</param>
+        ///// <param name="token">Secret token which links these logs to your logset/account.</param>
+        ///// <param name="region">Region to send data to. User: au, eu, us, ca, jp.</param>
+        ///// <param name="useSsl">Use SSL or not. (SSl -might- have a slight performance hit, but don't quote me on that).</param>
+        ///// <param name="restrictedToMinimumLevel">The minimum level for events passed through the sink. Ignored when levelSwitch is specified.</param>
+        ///// <param name="formatter">The formatter to log events in a textual representation. E.G. a compact Json representation for structured logging.</param>
+        ///// <param name="levelSwitch">A switch allowing the pass-through minimum level to be changed at runtime.</param>
+        ///// <returns></returns>
+        //public static LoggerConfiguration InsightOps(
+        //    this LoggerSinkConfiguration sinkConfiguration,
+        //    string token,
+        //    string region,
+        //    ITextFormatter formatter = null,
+        //    bool useSsl = true,
+        //    LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+        //    LoggingLevelSwitch levelSwitch = null)
+        //{
+        //    // We need a formatter, so lets use the other constructor.
+        //    if (formatter == null)
+        //    {
+        //        return InsightOps(sinkConfiguration, token, region, useSsl, restrictedToMinimumLevel, DefaultOutputTemplate, null, levelSwitch);
+        //    }
+
+        //    // We have a custom formatter, so we need to use the custom output template.
+        //    return InsightOps(sinkConfiguration, token, region, useSsl, formatter, restrictedToMinimumLevel, levelSwitch);
+        //}
+
+        ///// <summary>
+        ///// Configuration file POCO class: writes events logs to insightOps.
+        ///// </summary>
+        ///// <param name="sinkConfiguration">Logger sink configuration.</param>
+        ///// <param name="settings">Configuration settings.</param>
+        ///// <param name="restrictedToMinimumLevel">The minimum level for events passed through the sink. Ignored when levelSwitch is specified.</param>
+        ///// <param name="outputTemplate">Custom output template. If not provided, will default to <code>[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}</code></param>
+        ///// <param name="formatProvider">Optional: Supplies culture-specific formatting information, or null.</param>
+        ///// <param name="levelSwitch">A switch allowing the pass-through minimum level to be changed at runtime.</param>
+        ///// <returns></returns>
+        //public static LoggerConfiguration InsightOps(
+        //    this LoggerSinkConfiguration sinkConfiguration,
+        //    string token,
+        //    string region,
+        //    bool useSsl = true,
+        //    LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+        //    string outputTemplate = DefaultOutputTemplate,
+        //    IFormatProvider formatProvider = null,
+        //    LoggingLevelSwitch levelSwitch = null)
+        //{
+        //    if (string.IsNullOrWhiteSpace(outputTemplate))
+        //    {
+        //        throw new ArgumentException($"'{nameof(outputTemplate)}' cannot be null or whitespace", nameof(outputTemplate));
+        //    }
+
+        //    var formatter = new MessageTemplateTextFormatter(outputTemplate, formatProvider);
+
+        //    return sinkConfiguration.InsightOps(token, region, formatter, useSsl, restrictedToMinimumLevel, levelSwitch);
+        //}
+
+        ///// <summary>
+        ///// Configuration file POCO class: writes events logs to insightOps.
+        ///// </summary>
+        ///// <param name="sinkConfiguration">Logger sink configuration.</param>
+        ///// <param name="settings">Configuration settings.</param>
+        ///// <param name="formatter">The formatter to log events in a textual representation. E.G. a compact Json representation for structured logging.</param>
+        ///// <param name="restrictedToMinimumLevel">The minimum level for events passed through the sink. Ignored when levelSwitch is specified.</param>
+        ///// <param name="levelSwitch">A switch allowing the pass-through minimum level to be changed at runtime.</param>
+        ///// <returns></returns>
+        //public static LoggerConfiguration InsightOps(
+        //    this LoggerSinkConfiguration sinkConfiguration,
+        //    string token,
+        //    string region,
+        //    bool useSsl = true,
+        //    ITextFormatter formatter = null,
+        //    LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+        //    LoggingLevelSwitch levelSwitch = null)
+        //{
+        //    var settings = new InsightOpsSinkSettings
+        //    {
+        //        Token = token,
+        //        Region = region,
+        //        UseSsl = useSsl
+        //    };
+
+        //    ArgumentNullException.ThrowIfNull(formatter);
+
+        //    var sink = new InsightOpsSink(settings, formatter);
+
+        //    return sinkConfiguration.Sink(sink, restrictedToMinimumLevel, levelSwitch);
+        //}
     }
 }

--- a/src/Serilog.Sinks.InsightOps/Serilog.Sinks.InsightOps.csproj
+++ b/src/Serilog.Sinks.InsightOps/Serilog.Sinks.InsightOps.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <PackageId>Serilog.Sinks.InsightOps</PackageId>
     <Product>Serilog Sinks - Rapid7 InsightOps</Product>
     <Authors>Pure Krome</Authors>
@@ -14,22 +14,14 @@
     <RepositoryUrl>https://github.com/PureKrome/serilog-sinks-insightops</RepositoryUrl>
     <RepositoryType>c#</RepositoryType>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-
-    <!-- Source Link. REF: https://github.com/dotnet/sourcelink -->
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <PackageIcon>icon.png</PackageIcon>
     <PackageIconUrl />
     
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="R7Insight.Core" Version="2.9.3" />
-    <PackageReference Include="Serilog" Version="3.0.1" />
+    <PackageReference Include="Serilog" Version="3.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Serilog.Sinks.InsightOps.ConsoleTest/Program.cs
+++ b/tests/Serilog.Sinks.InsightOps.ConsoleTest/Program.cs
@@ -9,21 +9,28 @@ namespace Serilog.Sinks.InsightOps.ConsoleTest
         {
             // If something is wrong with our Serilog setup, 
             // lets make sure we can see what the problem is.
-            Debugging.SelfLog.Enable(msg => Console.WriteLine(msg));
+            //Debugging.SelfLog.Enable(msg => Console.WriteLine(msg));
             Debugging.SelfLog.Enable(Console.Error);
 
             Console.WriteLine("Starting.");
-            
+
             // NOTE: Please replace with your own settings.
-            const string region = "au"; // au, eu, jp or us.
-            const string token = "<some guid from your account>";
-            const bool useSsl = false;
+            var settings = new InsightOpsSinkSettings
+            {
+                //Token = Guid.Empty.ToString(),
+                Token = Guid.NewGuid().ToString(),
+                Region = "au", // au, eu, jp or us.,
+                UseSsl = false,
+                Debug = true
+            };
 
             // Create our logger.
             var log = new LoggerConfiguration()
                 .MinimumLevel.Debug()
-                .WriteTo.InsightOps(region, token, new RenderedCompactJsonFormatter(), useSsl)
-                .WriteTo.Console(new CompactJsonFormatter())
+                .WriteTo.InsightOps(settings)
+                //.WriteTo.InsightOps(settings, new RenderedCompactJsonFormatter())
+                .WriteTo.Console()
+                //.WriteTo.Console(new CompactJsonFormatter())
                 .WriteTo.Seq("http://localhost:5301")
                 .CreateLogger();
 

--- a/tests/Serilog.Sinks.InsightOps.ConsoleTest/Serilog.Sinks.InsightOps.ConsoleTest.csproj
+++ b/tests/Serilog.Sinks.InsightOps.ConsoleTest/Serilog.Sinks.InsightOps.ConsoleTest.csproj
@@ -2,13 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
-    <PackageReference Include="Serilog.Sinks.Seq" Version="5.2.2" />
+    <PackageReference Include="Serilog.Formatting.Compact" Version="2.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
+    <PackageReference Include="Serilog.Sinks.Seq" Version="7.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Serilog.Sinks.InsightOps.ConsoleWithConfigTest/Serilog.Sinks.InsightOps.ConsoleWithConfigTest.csproj
+++ b/tests/Serilog.Sinks.InsightOps.ConsoleWithConfigTest/Serilog.Sinks.InsightOps.ConsoleWithConfigTest.csproj
@@ -2,15 +2,15 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="7.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Serilog.Formatting.Compact" Version="2.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
     
   </ItemGroup>
 


### PR DESCRIPTION
- .NET 8 (and still NS20 for old, Full Framework crap)
- Redid the `LoggerSinkConfigurationExtensions` for an easier way to use the sink.
- 📝 Readme now represents the correct usage / how to use this product.